### PR TITLE
feat: Allow JavaScript extensions for TypeScript imports

### DIFF
--- a/src/require.ts
+++ b/src/require.ts
@@ -15,6 +15,39 @@ let env = (tsm as TSM).$defaults('cjs');
 let uconf = env.file && require(env.file);
 let config: Config = (tsm as TSM).$finalize(env, uconf);
 
+declare const $$req: NodeJS.Require;
+const tsrequire = 'var $$req=require.bind(require);' + function $$trap(src: string) {
+	let { existsSync } = $$req('fs');
+	let { URL, pathToFileURL } = $$req('url');
+	return new Proxy($$req, {
+		// NOTE: only here if source is TS
+		apply(req, ctx, args: [id: string]) {
+			let [ident] = args;
+			if (!ident) return req.apply(ctx || $$req, args);
+
+			// ignore "prefix:" and non-relative identifiers
+			if (/^\w+\:?/.test(ident)) return $$req(ident);
+
+			// exit early if no extension provided
+			let match = /\.([mc])?js(?=\?|$)/.exec(ident);
+			if (match == null) return $$req(ident);
+
+			let base = pathToFileURL(src) as import('url').URL;
+			let file = new URL(ident, base).pathname as string;
+			if (existsSync(file)) return $$req(ident);
+
+			// ?js -> ?ts file
+			file = file.replace(
+				new RegExp(match[0] + '$'),
+				match[0].replace('js', 'ts')
+			);
+
+			// return the new "[mc]ts" file, or let error
+			return existsSync(file) ? $$req(file) : $$req(ident);
+		}
+	})
+};
+
 function loader(Module: Module, sourcefile: string) {
 	let extn = extname(sourcefile);
 	let pitch = Module._compile!.bind(Module);
@@ -23,8 +56,13 @@ function loader(Module: Module, sourcefile: string) {
 		let options = config[extn];
 		if (options == null) return pitch(source, sourcefile);
 
+		let banner = options.banner || '';
+		if (/\.[mc]?tsx?$/.test(extn)) {
+			banner = tsrequire + `require=$$trap(${ JSON.stringify(sourcefile) });` + banner;
+		}
+
 		esbuild = esbuild || require('esbuild');
-		let result = esbuild.transformSync(source, { ...options, sourcefile });
+		let result = esbuild.transformSync(source, { ...options, banner, sourcefile });
 		return pitch(result.code, sourcefile);
 	};
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,6 @@ import type { Format } from 'esbuild';
 import type * as tsm from 'tsm/config';
 import type { Defaults } from './utils.d';
 
-
 exports.$defaults = function (format: Format): Defaults {
 	let { FORCE_COLOR, NO_COLOR, NODE_DISABLE_COLORS, TERM } = process.env;
 

--- a/test/config/index.ts
+++ b/test/config/index.ts
@@ -1,10 +1,20 @@
 import * as assert from 'assert';
 
+// NOTE: doesn't actually exist yet
+import * as js from '../fixtures/math.js';
+
 // NOTE: avoid need for syntheticDefault + analysis
 import * as data from '../fixtures/data.json';
 assert.equal(typeof data, 'object');
 
 // @ts-ignore - generally doesn't exist
 assert.equal(typeof data.default, 'string');
+
+// NOTE: raw JS missing
+assert.equal(typeof js, 'object', 'JS :: typeof');
+assert.equal(typeof js.sum, 'function', 'JS :: typeof :: sum');
+assert.equal(typeof js.div, 'function', 'JS :: typeof :: div');
+assert.equal(typeof js.mul, 'function', 'JS :: typeof :: mul');
+assert.equal(js.foobar, 3, 'JS :: value :: foobar');
 
 console.log('DONE~!');


### PR DESCRIPTION
Closes #1 

When inside any TypeScript file (`.ts`, `.tsx`, `.cts`, or `.mts`) you may now write `import` statements to other TypeScript files, but using their would-be JavaScript extensions.

For example, assume this file structure:

```
demo
├── aaa.ts
├── bbb.cts
├── ccc.mts
└── main.ts
```

And now the `main.ts` file includes the following:

```ts
import aaa from './aaa.js';
// => loads the "aaa.ts" file

import bbb from './bbb.cjs';
// => loads the "bbb.cts" file

import ccc from './ccc.mjs';
// => loads the "ccc.mts" file
```

This is/will be supported officially by TypeScript. See [here for more info](https://twitter.com/orta/status/1444958295865937920)