### PR TITLE
fix(require): handle `ERR_REQUIRE_ESM` error 

### DIFF
--- a/src/require.ts
+++ b/src/require.ts
@@ -51,23 +51,20 @@ const tsrequire = 'var $$req=require;require=(' + function () {
 } + ')();';
 
 function transform(source: string, sourcefile: string, options: Options): string {
-	let banner = options.banner || '';
-	if (/\.[mc]?tsx?$/.test(sourcefile)) {
-		banner = tsrequire + banner;
-	}
-
 	esbuild = esbuild || require('esbuild');
-	return esbuild.transformSync(source, {
-		...options, banner, sourcefile
-	}).code;
+	return esbuild.transformSync(source, { ...options, sourcefile }).code;
 }
 
 function loader(Module: Module, sourcefile: string) {
-	let pitch = Module._compile!.bind(Module);
 	let extn = extname(sourcefile);
-	let options = config[extn];
+	let options = config[extn] || {};
+	let pitch = Module._compile!.bind(Module);
 
-	if (options != null) {
+	if (/\.[mc]?tsx?$/.test(extn)) {
+		options.banner = tsrequire + (options.banner || '');
+	}
+
+	if (config[extn] != null) {
 		Module._compile = source => {
 			let result = transform(source, sourcefile, options);
 			return pitch(result, sourcefile);

--- a/src/require.ts
+++ b/src/require.ts
@@ -17,11 +17,11 @@ let uconf = env.file && require(env.file);
 let config: Config = (tsm as TSM).$finalize(env, uconf);
 
 declare const $$req: NodeJS.Require;
-const tsrequire = 'var $$req=require;require=(' + function () {
+const tsrequire = 'var $$req=require("module").createRequire(__filename);require=(' + function () {
 	let { existsSync } = $$req('fs');
 	let { URL, pathToFileURL } = $$req('url');
 
-	return new Proxy($$req, {
+	return new Proxy(require, {
 		// NOTE: only here if source is TS
 		apply(req, ctx, args: [id: string]) {
 			let [ident] = args;

--- a/test/config/index.ts
+++ b/test/config/index.ts
@@ -6,6 +6,8 @@ import * as js from '../fixtures/math.js';
 import * as mjs from '../fixtures/utils.mjs';
 // @ts-ignore - cannot find types
 import * as cjs from '../fixtures/utils.cjs';
+// @ts-ignore - cannot find types
+import * as esm from '../fixtures/module/index.js';
 
 // NOTE: avoid need for syntheticDefault + analysis
 import * as data from '../fixtures/data.json';
@@ -30,5 +32,12 @@ assert.equal(mjs.capitalize('hello'), 'Hello', 'MJS :: value :: capitalize');
 assert.equal(typeof cjs, 'object', 'CJS :: typeof');
 assert.equal(typeof cjs.dashify, 'function', 'CJS :: typeof :: dashify');
 assert.equal(cjs.dashify('FooBar'), 'foo-bar', 'CJS :: value :: dashify');
+
+// Checking ".js" with ESM content (type: module)
+assert.equal(typeof esm, 'object', 'ESM.js :: typeof');
+// @ts-ignore
+assert.equal(typeof esm.hello, 'function', 'ESM.js :: typeof :: hello');
+// @ts-ignore
+assert.equal(esm.hello('you'), 'hello, you', 'ESM.js :: value :: hello');
 
 console.log('DONE~!');

--- a/test/fixtures/module/index.js
+++ b/test/fixtures/module/index.js
@@ -1,0 +1,6 @@
+/**
+ * @param {string} name
+ */
+export function hello(name) {
+	return `hello, ${name}`;
+}

--- a/test/fixtures/module/index.mjs
+++ b/test/fixtures/module/index.mjs
@@ -1,0 +1,6 @@
+/**
+ * @param {string} name
+ */
+export function hello(name) {
+	return `hello, ${name}`;
+}

--- a/test/fixtures/module/package.json
+++ b/test/fixtures/module/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,10 @@ const ts = require('./fixtures/math.ts');
 const mts = require('./fixtures/utils.mts');
 // @ts-ignore – prefers extensionless
 const cts = require('./fixtures/utils.cts');
+// @ts-ignore – prefers extensionless
+const esm1 = require('./fixtures/module/index.js');
+// @ts-ignore – prefers extensionless
+const esm2 = require('./fixtures/module/index.mjs');
 
 const props = {
 	foo: 'bar'
@@ -54,5 +58,15 @@ assert(cts, 'CTS :: typeof');
 assert.equal(typeof cts, 'object', 'CTS :: typeof');
 assert.equal(typeof cts.dashify, 'function', 'CTS :: typeof :: dashify');
 assert.equal(cts.dashify('FooBar'), 'foo-bar', 'CTS :: value :: dashify');
+
+assert(esm1, 'ESM.js :: typeof');
+assert.equal(typeof esm1, 'object', 'ESM.js :: typeof');
+assert.equal(typeof esm1.hello, 'function', 'ESM.js :: typeof :: hello');
+assert.equal(esm1.hello('you'), 'hello, you', 'ESM.js :: value :: hello');
+
+assert(esm2, 'ESM.mjs :: typeof');
+assert.equal(typeof esm2, 'object', 'ESM.mjs :: typeof');
+assert.equal(typeof esm2.hello, 'function', 'ESM.mjs :: typeof :: hello');
+assert.equal(esm2.hello('you'), 'hello, you', 'ESM.mjs :: value :: hello');
 
 console.log('DONE~!');

--- a/test/index.mjs
+++ b/test/index.mjs
@@ -11,6 +11,10 @@ import * as cts from './fixtures/utils.cts';
 import * as ts from './fixtures/math.ts';
 // @ts-ignore – prefers extensionless
 import tsx from './fixtures/App2.tsx';
+// @ts-ignore – prefers extensionless
+import * as esm1 from './fixtures/module/index.js';
+// @ts-ignore – prefers extensionless
+import * as esm2 from './fixtures/module/index.mjs';
 
 const props = {
 	foo: 'bar'
@@ -52,5 +56,13 @@ assert.equal(mts.capitalize('hello'), 'Hello', 'MTS :: value :: capitalize');
 assert.equal(typeof cts, 'object', 'CTS :: typeof');
 assert.equal(typeof cts.dashify, 'function', 'CTS :: typeof :: dashify');
 assert.equal(cts.dashify('FooBar'), 'foo-bar', 'CTS :: value :: dashify');
+
+assert.equal(typeof esm1, 'object', 'ESM.js :: typeof');
+assert.equal(typeof esm1.hello, 'function', 'ESM.js :: typeof :: hello');
+assert.equal(esm1.hello('you'), 'hello, you', 'ESM.js :: value :: hello');
+
+assert.equal(typeof esm2, 'object', 'ESM.mjs :: typeof');
+assert.equal(typeof esm2.hello, 'function', 'ESM.mjs :: typeof :: hello');
+assert.equal(esm2.hello('you'), 'hello, you', 'ESM.mjs :: value :: hello');
 
 console.log('DONE~!');


### PR DESCRIPTION
Previously, tsm didn't handle the case where you could `require` a `foo.js` file that contained ESM syntax. Even though this combination is/should be invalid, tsm has to be able to rewrite the file(s) as necessary in the event there's a series or combination of tools that produce this scenario. 

For example, you could be writing tests in TypeScript & those tests import third-party code that's written in ESM within `.js` files. When executing those tests with a require hook – for example `uvu -r tsm tests` – then the TypeScript would be converted into CommonJS, making `require()` calls to the third-party `".js"` file, which still contains ESM. This would fail.

This is implemented in a way such that `node -r tsm` does _nothing_ to `.js` files by default. It will **only** retry a `.js` file if the `ERR_REQUIRE_ESM` error was thrown. In fact, if _any_ loader (regardless of extension) attempts to execute but throws the `ERR_REQUIRE_ESM` error, then the file is retried w/ the same options, but forcing `format: cjs` the second time around.

> **Note:** If you add custom configuration for `.js` files, then tsm will respect that and follow your directions anyway. Your config will always execute, **not** just when the `ERR_REQUIRE_ESM` error is thrown.

---

Closes #7 