### PR TITLE
fix: support new ESM loader API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 3
     strategy:
       matrix:
-        nodejs: [12, 14, 16]
+        nodejs: [12, 14, 16.11, 16]
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is done in a way that supports **both** ESM loader hook designs. It's duplicative, but luckily A) it's not much code in the first place; and B) it works 😆 

IMO it's really important to support both designs right now, because while fresh `16.x` installations (and presumably everything else going forward) will only use/need the new `load` hook, alllllll previous 14 and 16 versions that people may be using use the old design.

At some future point – once the API design & probably when there's a 16 LTS version – I can remove the old loader hooks and cut a new major version that raises/restricts the `engines` requirement.

Closes #13
