### PR TITLE
Remove passing load fallback to itself as an argument

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -40,15 +40,17 @@ type Transform = (
 	fallback: Transform
 ) => Promisable<{ source: Source }>;
 
-type Load = (
-	url: string,
-	context: { format?: Format },
-	fallback: Load
-) => Promisable<{
+type LoadResult = Promisable<{
 	format: Format;
 	shortCircuit: boolean;
 	source: Source;
-}>;
+}>
+
+type Load = (
+	url: string,
+	context: { format?: Format },
+	fallback: (url: string, context: { format?: Format }) => LoadResult
+) => LoadResult;
 
 async function toConfig(): Promise<Config> {
 	let mod = await setup;
@@ -136,7 +138,7 @@ export const resolve: Resolve = async function (ident, context, fallback) {
 export const load: Load = async function (uri, context, fallback) {
 	// note: inline `getFormat`
 	let options = await toOptions(uri);
-	if (options == null) return fallback(uri, context, fallback);
+	if (options == null) return fallback(uri, context);
 	let format: Format = options.format === 'cjs' ? 'commonjs' : 'module';
 
 	// TODO: decode SAB/U8 correctly


### PR DESCRIPTION
And updates types accordingly.
Looking at the docs, there's no 3rd argument to the fallback and it doesn't really make sense to pass fallback itself.

https://nodejs.org/api/esm.html#loadurl-context-nextload

I guess its presense doesn't really hurt but it's redundant so I took the liberty of fixing it.
Let me know what you think if you have any concerns.
