### PR TITLE
feat: Use fallback resolver to resolve subpath imports

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -85,8 +85,8 @@ const MAPs: Record<Extension, Extension[]> = {
 
 const root = new URL('file:///' + process.cwd() + '/');
 export const resolve: Resolve = async function (ident, context, fallback) {
-	// ignore "prefix:" and non-relative identifiers
-	if (/^\w+\:?/.test(ident)) return fallback(ident, context, fallback);
+	// ignore "prefix:", non-relative identifiers, and subpath imports
+	if (/^\w+\:?/.test(ident) || ident.startsWith('#')) return fallback(ident, context, fallback);
 
 	let target = new URL(ident, context.parentURL || root);
 	let ext: Extension, path: string | void, arr: Extension[];


### PR DESCRIPTION
Right now, tsm resolves `#subpath-import` on its own which resolves to the same file imported `#subpath-import`. The PR uses fallback resolver to get a proper file name.

Have not found any way to test the behaviour on the repo, although it works if you apply the same modifications to a compiled JS code of TSM.